### PR TITLE
Add bootsnap to no_database Gemfile

### DIFF
--- a/features/no_database.feature
+++ b/features/no_database.feature
@@ -34,6 +34,7 @@ Feature: No Database
       gem "cucumber-rails", group: :test, path: "../../.."
       gem "capybara", group: :test
       gem "rspec-rails", group: :test
+      gem "bootsnap", require: false
       if RUBY_VERSION >= '2.0.0'
         gem 'sass-rails'
         gem 'uglifier'


### PR DESCRIPTION
I believe the `no_database.feature` will fail on Rails 5.2 because `bootsnap` is missing from the `Gemfile` that the feature generates. I have a [failing CI build here](https://travis-ci.org/cucumber/cucumber-rails/jobs/368127799#L2005) because of this issue, and I believe adding this gem to the Gemfile will fix this problem.

This will not affect other Rails versions because no other Rails version requires `bootsnap/setup`.