### PR TITLE
Make click_with_javascript_emulation take any args

### DIFF
--- a/lib/cucumber/rails/capybara/javascript_emulation.rb
+++ b/lib/cucumber/rails/capybara/javascript_emulation.rb
@@ -9,7 +9,7 @@ module Cucumber
           end
         end
 
-        def click_with_javascript_emulation
+        def click_with_javascript_emulation(*)
           if link_with_non_get_http_method?
             ::Capybara::RackTest::Form.new(driver, js_form(element_node.document, self[:href], emulated_method)).submit(self)
           else


### PR DESCRIPTION
During the "Delete Widgets" test, this happens:

    When I follow "Destroy"                 # features/step_definitions/web_steps.rb:48
      wrong number of arguments (given 2, expected 0) (ArgumentError)
      /Users/ryanbigg/code/gems/cucumber-rails/lib/cucumber/rails/capybara/javascript_emulation.rb:12:in `click_with_javascript_emulation'
      /usr/local/Cellar/asdf/0.4.1/installs/ruby/2.4.4/lib/ruby/gems/2.4.0/gems/capybara-3.0.2/lib/capybara/node/element.rb:133:in `block in click'
      /usr/local/Cellar/asdf/0.4.1/installs/ruby/2.4.4/lib/ruby/gems/2.4.0/gems/capybara-3.0.2/lib/capybara/node/base.rb:83:in `synchronize'
      /usr/local/Cellar/asdf/0.4.1/installs/ruby/2.4.4/lib/ruby/gems/2.4.0/gems/capybara-3.0.2/lib/capybara/node/element.rb:133:in `click'
      /usr/local/Cellar/asdf/0.4.1/installs/ruby/2.4.4/lib/ruby/gems/2.4.0/gems/capybara-3.0.2/lib/capybara/node/actions.rb:41:in `click_link'
      /usr/local/Cellar/asdf/0.4.1/installs/ruby/2.4.4/lib/ruby/gems/2.4.0/gems/capybara-3.0.2/lib/capybara/session.rb:740:in `block (2 levels) in <class:Session>'
      /usr/local/Cellar/asdf/0.4.1/installs/ruby/2.4.4/lib/ruby/gems/2.4.0/gems/capybara-3.0.2/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
      /Users/ryanbigg/code/gems/cucumber-rails/tmp/aruba/test_app/features/step_definitions/web_steps.rb:49:in `block in <main>'

  This is because Capybara 3 now passes two additional arguments to
  Cucumber's method. But this Cucumber method needs to do nothing with
  those arguments other than accept them.

  This will make the "Deleting a widget" test pass once again.

You can see a shorter version of this same stacktrace during my fork's travis build: https://travis-ci.org/radar/cucumber-rails/jobs/368489987#L1024